### PR TITLE
Fixed TS1 for 500kbit/s

### DIFF
--- a/stm32-slcan.c
+++ b/stm32-slcan.c
@@ -116,7 +116,7 @@ static int can_speed(int index)
 	 100 kBaud Sample Point 80.0 % : 36MHZ /  36 = 1MHz   -> TQ 10   SJW + TS1  8 TS2 2
 	 125 kBaud Sample Point 87.5 % : 36MHZ /  18 = 2MHz   -> TQ 16   SJW + TS1 14 TS2 2 
 	 250 kBaud Sample Point 87.5 % : 36MHZ /   9 = 4MHz   -> TQ 16   SJW + TS1 14 TS2 2
-	 500 kBaud Sample Point 87.5 % : 36MHZ /   9 = 4MHz   -> TQ  8   SJW + TS1  7 TS2 1
+	 500 kBaud Sample Point 87.5 % : 36MHZ /   9 = 4MHz   -> TQ  8   SJW + TS1  6 TS2 1
 	 800 kBaud Sample Point 86.7 % : 36MHZ /   3 = 12MHz  -> TQ 15   SJW + TS1 13 TS2 2
 	 1000 kBaud Sample Point 88.9 % : 36MHZ /   2 = 18MHz  -> TQ 18   SJW + TS1 16 TS2 2
 
@@ -160,7 +160,7 @@ static int can_speed(int index)
         break;
     case 6:
         ret = can_init(CAN1, false, true, false, false, false, false,
-            CAN_BTR_SJW_1TQ, CAN_BTR_TS1_7TQ, CAN_BTR_TS2_1TQ, 9, false,
+            CAN_BTR_SJW_1TQ, CAN_BTR_TS1_6TQ, CAN_BTR_TS2_1TQ, 9, false,
             false);
         break;
     case 7:


### PR DESCRIPTION
The current TS1 is too large for a baud rate of 500 kbit/s, and results in a baud rate of 444 kbit/s when `-s6` is specified.